### PR TITLE
[ADD] add acsone-public-module template

### DIFF
--- a/acsone-public-module/README.rst
+++ b/acsone-public-module/README.rst
@@ -1,0 +1,55 @@
+{{ name }}
+{{ '=' * name|length }}
+
+This module was written to extend the functionality of ... to support ... and allow you to ...
+
+Installation
+============
+
+To install this module, you need to:
+
+ * do this ...
+
+Configuration
+=============
+
+To configure this module, you need to:
+
+ * go to ...
+
+Usage
+=====
+
+To use this module, you need to:
+
+ * go to ...
+
+For further information, please visit:
+
+ * https://www.odoo.com/forum/help-1
+
+Known issues / Roadmap
+======================
+
+ * ...
+
+Credits
+=======
+
+Contributors
+------------
+
+* Firsname Lastname <email.address@acsone.eu>
+
+Maintainer
+----------
+
+.. image:: http://odoo-community.org/logo.png
+   :alt: Odoo Community Association
+   :target: http://odoo-community.org
+
+This module is maintained by the OCA.
+
+OCA, or the Odoo Community Association, is a nonprofit organization whose mission is to support the collaborative development of Odoo features and promote its widespread use.
+
+To contribute to this module, please visit http://odoo-community.org.

--- a/acsone-public-module/__init__.py
+++ b/acsone-public-module/__init__.py
@@ -1,0 +1,3 @@
+# -*- coding: utf-8 -*-
+from . import controllers
+from . import models

--- a/acsone-public-module/__openerp__.py
+++ b/acsone-public-module/__openerp__.py
@@ -39,6 +39,7 @@
     # Check http://goo.gl/0TfwzD for the full list
     'category': 'Uncategorized',
     'version': '0.1',
+    'license': 'AGPL-3',
 
     # any module necessary for this one to work correctly
     'depends': [

--- a/acsone-public-module/__openerp__.py
+++ b/acsone-public-module/__openerp__.py
@@ -1,0 +1,57 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#     This file is part of {{ name }}, an Odoo module.
+#
+#     Copyright (c) 2015 ACSONE SA/NV (<http://acsone.eu>)
+#
+#     {{ name }} is free software: you can redistribute it and/or
+#     modify it under the terms of the GNU Affero General Public License
+#     as published by the Free Software Foundation, either version 3 of
+#     the License, or (at your option) any later version.
+#
+#     {{ name }} is distributed in the hope that it will be useful,
+#     but WITHOUT ANY WARRANTY; without even the implied warranty of
+#     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#     GNU Affero General Public License for more details.
+#
+#     You should have received a copy of the
+#     GNU Affero General Public License
+#     along with {{ name }}.
+#     If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+{
+    'name': "{{ name }}",
+
+    'summary': """
+        Short (1 phrase/line) summary of the module's purpose, used as
+        subtitle on modules listing or apps.openerp.com""",
+
+    'description': """
+        Long description of module's purpose
+    """,
+
+    'author': "ACSONE SA/NV",
+    'website': "http://acsone.eu",
+
+    # Categories can be used to filter modules in modules listing
+    # Check http://goo.gl/0TfwzD for the full list
+    'category': 'Uncategorized',
+    'version': '0.1',
+
+    # any module necessary for this one to work correctly
+    'depends': [
+        'base',
+    ],
+
+    # always loaded
+    'data': [
+        # 'security/ir.model.access.csv',
+        'templates.xml',
+    ],
+    # only loaded in demonstration mode
+    'demo': [
+        'demo.xml',
+    ],
+}

--- a/acsone-public-module/__openerp__.py
+++ b/acsone-public-module/__openerp__.py
@@ -28,9 +28,7 @@
         Short (1 phrase/line) summary of the module's purpose, used as
         subtitle on modules listing or apps.openerp.com""",
 
-    'description': """
-        Long description of module's purpose
-    """,
+    # 'description': put the module description in README.rst
 
     'author': "ACSONE SA/NV",
     'website': "http://acsone.eu",

--- a/acsone-public-module/controllers.py
+++ b/acsone-public-module/controllers.py
@@ -1,0 +1,46 @@
+{%- set mod = name|snake -%}
+{%- set model = "%s.%s"|format(mod, mod) -%}
+{%- set root = "/%s/%s"|format(mod, mod) -%}
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#     This file is part of {{ name }}, an Odoo module.
+#
+#     Copyright (c) 2015 ACSONE SA/NV (<http://acsone.eu>)
+#
+#     {{ name }} is free software: you can redistribute it and/or
+#     modify it under the terms of the GNU Affero General Public License
+#     as published by the Free Software Foundation, either version 3 of
+#     the License, or (at your option) any later version.
+#
+#     {{ name }} is distributed in the hope that it will be useful,
+#     but WITHOUT ANY WARRANTY; without even the implied warranty of
+#     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#     GNU Affero General Public License for more details.
+#
+#     You should have received a copy of the
+#     GNU Affero General Public License
+#     along with {{ name }}.
+#     If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+
+from openerp import http
+
+# class {{ mod|pascal }}(http.Controller):
+#     @http.route('{{ root }}/', auth='public')
+#     def index(self, **kw):
+#         return "Hello, world"
+
+#     @http.route('{{ root }}/objects/', auth='public')
+#     def list(self, **kw):
+#         return http.request.render('{{ mod }}.listing', {
+#             'root': '{{ root }}',
+#             'objects': http.request.env['{{ model }}'].search([]),
+#         })
+
+#     @http.route('{{ root }}/objects/<model("{{ model }}"):obj>/', auth='public')
+#     def object(self, obj, **kw):
+#         return http.request.render('{{ mod }}.object', {
+#             'object': obj
+#         })

--- a/acsone-public-module/demo.xml
+++ b/acsone-public-module/demo.xml
@@ -1,0 +1,11 @@
+{%- set mod= name|snake -%}
+{%- set model = "%s.%s"|format(mod, mod) -%}
+<openerp>
+    <data>
+        <!-- {% for item in range(5) %} -->
+        <!--   <record id="object{{ item }}" model="{{ model }}"> -->
+        <!--     <field name="name">Object {{ item }}</field> -->
+        <!--   </record> -->
+        <!-- {% endfor %} -->
+    </data>
+</openerp>

--- a/acsone-public-module/models.py
+++ b/acsone-public-module/models.py
@@ -1,0 +1,30 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#     This file is part of {{ name }}, an Odoo module.
+#
+#     Copyright (c) 2015 ACSONE SA/NV (<http://acsone.eu>)
+#
+#     {{ name }} is free software: you can redistribute it and/or
+#     modify it under the terms of the GNU Affero General Public License
+#     as published by the Free Software Foundation, either version 3 of
+#     the License, or (at your option) any later version.
+#
+#     {{ name }} is distributed in the hope that it will be useful,
+#     but WITHOUT ANY WARRANTY; without even the implied warranty of
+#     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#     GNU Affero General Public License for more details.
+#
+#     You should have received a copy of the
+#     GNU Affero General Public License
+#     along with {{ name }}.
+#     If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+
+from openerp import models, fields, api
+
+# class {{ name|snake }}(models.Model):
+#     _name = '{{ name|snake }}.{{ name|snake }}'
+
+#     name = fields.Char()

--- a/acsone-public-module/security/ir.model.access.csv
+++ b/acsone-public-module/security/ir.model.access.csv
@@ -1,0 +1,6 @@
+{%- set snake_name = name|snake -%}
+{%- set id = "access_%s_%s"|format(snake_name, snake_name) -%}
+{%- set name = "%s.%s"|format(snake_name, snake_name) -%}
+{%- set model_id = "model_%s_%s"|format(snake_name, snake_name) -%}
+id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
+{{ id }},{{ name }},{{ model_id }},,1,0,0,0

--- a/acsone-public-module/templates.xml
+++ b/acsone-public-module/templates.xml
@@ -1,0 +1,22 @@
+<openerp>
+    <data>
+        <!-- <template id="listing"> -->
+        <!--   <ul> -->
+        <!--     <li t-foreach="objects" t-as="object"> -->
+        <!--       <a t-attf-href="#{ root }/objects/#{ object.id }"> -->
+        <!--         <t t-esc="object.display_name"/> -->
+        <!--       </a> -->
+        <!--     </li> -->
+        <!--   </ul> -->
+        <!-- </template> -->
+        <!-- <template id="object"> -->
+        <!--   <h1><t t-esc="object.display_name"/></h1> -->
+        <!--   <dl> -->
+        <!--     <t t-foreach="object._fields" t-as="field"> -->
+        <!--       <dt><t t-esc="field"/></dt> -->
+        <!--       <dd><t t-esc="object[field]"/></dd> -->
+        <!--     </t> -->
+        <!--   </dl> -->
+        <!-- </template> -->
+    </data>
+</openerp>


### PR DESCRIPTION
This requires https://github.com/odoo/odoo/pull/4767 so odoo.py scaffold -t <template> accepts a directory instead of a builtin template, as documented in odoo.py scaffold -h.
